### PR TITLE
Minor updates for VSLive Chicago + removal of unnecessary imports for standalone components

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -29,7 +29,7 @@ export class AppComponent {
   public today: number = Date.now();
 
   ngOnInit() {
-    this.className = `Visual Studio LIVE! Las Vegas | Environment: ${environment.name}`;
+    this.className = `Visual Studio LIVE! Chicago | Environment: ${environment.name}`;
   }
 
 }

--- a/src/app/reservations/reservation.component.ts
+++ b/src/app/reservations/reservation.component.ts
@@ -15,7 +15,6 @@ import { CABINS } from '../cabins/models/mock-cabins';
   selector: 'app-reservation',
   standalone: true,
   imports: [
-    CommonModule,
     FormsModule,
     MatNativeDateModule,
     MatDatepickerModule,

--- a/src/app/specials/specials.component.ts
+++ b/src/app/specials/specials.component.ts
@@ -7,7 +7,6 @@ import { MatCardModule } from '@angular/material/card';
   selector: 'app-specials',
   standalone: true,
   imports: [
-    CommonModule,
     MatButtonModule,
     MatCardModule
   ],


### PR DESCRIPTION
This pull request primarily includes changes to the `src/app` directory, focusing on modifying import statements and updating the `AppComponent` class. The most significant changes are the update to the `className` in `AppComponent`, and the removal of `CommonModule` from the import statements in `reservation.component.ts` and `specials.component.ts`.

Updates to `AppComponent`:

* [`src/app/app.component.ts`](diffhunk://#diff-884f7f49640e5923f6bcac4c51d90340330a178f662defbe61e5f5aac1c512deL32-R32): Updated the `className` in the `AppComponent` class to reflect the change of location from Las Vegas to Chicago.

Changes to import statements:

* [`src/app/reservations/reservation.component.ts`](diffhunk://#diff-9ba9800bd408a3e8e7fd34d5964332e829115140e65374f3c63b2ad4a8e7ade0L18): Removed `CommonModule` from the import statements, leaving `FormsModule`, `MatNativeDateModule`, and `MatDatepickerModule`.
* [`src/app/specials/specials.component.ts`](diffhunk://#diff-ef66f33996c68f064c415e68b2e136804f28f7620dbf375c138387dc08066811L10): Removed `CommonModule` from the import statements, leaving `MatButtonModule` and `MatCardModule`.… standalone components